### PR TITLE
chore: build Kiali from Alauda fork branches

### DIFF
--- a/wolfi/kiali-2.17.1.yaml
+++ b/wolfi/kiali-2.17.1.yaml
@@ -27,9 +27,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/kiali/kiali
-      tag: v${{package.version}}
-      expected-commit: 0c485691ce81338523f24f8f0b67b2749d4987aa
+      repository: https://github.com/alauda-mesh/kiali
+      branch: kiali-2.17.1
+
+  - runs: |
+      echo "Kiali source branch: kiali-2.17.1"
+      echo "Kiali source commit: $(git rev-parse HEAD)"
+      git log -1 --format='Kiali source commit details: %H %cI %s'
 
   - runs: make clean-all build-ui
 

--- a/wolfi/kiali-2.22.2.yaml
+++ b/wolfi/kiali-2.22.2.yaml
@@ -27,9 +27,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/kiali/kiali
-      tag: v${{package.version}}
-      expected-commit: 7769925d203b808819854a91722256291596b802
+      repository: https://github.com/alauda-mesh/kiali
+      branch: kiali-2.22.2
+
+  - runs: |
+      echo "Kiali source branch: kiali-2.22.2"
+      echo "Kiali source commit: $(git rev-parse HEAD)"
+      git log -1 --format='Kiali source commit details: %H %cI %s'
 
   - runs: |
       # v2.22.2 前端通过 corepack 管理 Yarn 4，不能复用系统自带的 Yarn 1.x。

--- a/wolfi/kiali-2.27.1.yaml
+++ b/wolfi/kiali-2.27.1.yaml
@@ -27,9 +27,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/kiali/kiali
-      tag: v${{package.version}}
-      expected-commit: 6f3ab7567386098885a45afcd86311868974f77e
+      repository: https://github.com/alauda-mesh/kiali
+      branch: kiali-2.27.1
+
+  - runs: |
+      echo "Kiali source branch: kiali-2.27.1"
+      echo "Kiali source commit: $(git rev-parse HEAD)"
+      git log -1 --format='Kiali source commit details: %H %cI %s'
 
   - runs: |
       # v2.27.1 前端仍通过 corepack 管理 Yarn 4（packageManager=yarn@4.12.0，要求 node>=24），不能复用系统自带的 Yarn 1.x。


### PR DESCRIPTION
## 变更

- 将三个 Kiali Melange 流水线切换到 alauda-mesh/kiali fork
- 分别跟踪 kiali-2.17.1、kiali-2.22.2 和 kiali-2.27.1 分支
- 不设置 expected-commit，以便每次构建使用分支最新提交
- 在构建日志中输出实际 checkout 的分支、完整 commit SHA、提交时间和标题

## 验证

- 三个配置均通过 melange compile --arch x86_64 校验
- git diff --check 通过

本次只修改 build-kiali 构建配置，不修改 fork 分支中的 Kiali 源码或依赖。